### PR TITLE
allow use of pattern when uploading file

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ plugins: [
     projectId: '123', // airbrake project id
     projectKey: 'a1b2c3', // airbrake project/auth key
     host: 'https://www.github.com/dist', // your website url where the distribution files will be hosted
+    patternForFile: (_path, file) => file.replace(/\.map$/, ''), // (optional) for server side files (return `undefined` when file do not need a pattern)
     directories: ['wwwroot', 'dist'], // directories to scan and upload sourcemaps from
     logging: false, // boolean to show or hide plugin logs
   })

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ AirbrakePlugin.prototype.apply = function(compiler) {
     /*
      * Get options values
      */
-    const { projectId, projectKey, host, logging, removeAfterUpload } = this.options;
+    const { projectId, projectKey, host, logging, removeAfterUpload, patternForFile } = this.options;
 
     /*
      * Upload file to sourcemaps
@@ -32,6 +32,9 @@ AirbrakePlugin.prototype.apply = function(compiler) {
             }
 
             const airbrakeUrl = `https://airbrake.io/api/v4/projects/${projectId}/sourcemaps`;
+            const pattern = patternForFile && typeof patternForFile === 'function'
+              ? patternForFile(path, file)
+              : undefined
 
             const postData = {
                 headers: {
@@ -41,6 +44,7 @@ AirbrakePlugin.prototype.apply = function(compiler) {
                 formData: {
                     file: fs.createReadStream(filePath),
                     name: `${host}/${file}`,
+                    pattern,
                     buffer: new Buffer([1, 2, 3])
                 },
             };


### PR DESCRIPTION
I have a vue/nuxt app and sourcemaps were not working for the server (SSR) context

code to use in `nuxt.config.js` : 
```
    extend(config, { isDev, isClient }) {
      config.devtool = 'source-map'

      if (isDev) return
      if (isClient) return

      config.plugins.push(
        new AirbrakeSourcemapsWebpackPlugin({
          projectId,
          projectKey,
          host: '*', // useless for server side
          patternForFile: (_path, file) => file.replace(/\.map$/, ''),
          directories: ['.nuxt/dist/client', '.nuxt/dist/server'],
          logging: true
        })
      )
    }
```
(`config` being the webpack config object)

context debug info passed from
```
  "sourceMapErrors": {
    "/app/node_modules/vue-server-renderer/build.prod.js": "got \"/app/node_modules/vue-server-renderer/build.prod.js\", expected an absolute URL",
    "/app/node_modules/vue/dist/vue.runtime.common.prod.js": "got \"/app/node_modules/vue/dist/vue.runtime.common.prod.js\", expected an absolute URL",
    "cfca8728cc0c82e8ef28.js": "got \"cfca8728cc0c82e8ef28.js\", expected an absolute URL"
  },
```

to
```
  "sourceMapErrors": {
    "/app/node_modules/vue-server-renderer/build.prod.js": "got \"/app/node_modules/vue-server-renderer/build.prod.js\", expected an absolute URL",
    "/app/node_modules/vue/dist/vue.runtime.common.prod.js": "got \"/app/node_modules/vue/dist/vue.runtime.common.prod.js\", expected an absolute URL"
  },
  "usedSourceMaps": {
    "33b3d2f63547ceea17b8.js": "33b3d2f63547ceea17b8.js.map"
  },
```

N.B. : I'm still having a issue with the sourcemap, the line exposed on airbrake.io does not correspond to the correct source file line (the file name/path is correct tho)